### PR TITLE
Adding lane mmr into matchmaking

### DIFF
--- a/inhouse_bot/matchmaking_logic/evaluate_game.py
+++ b/inhouse_bot/matchmaking_logic/evaluate_game.py
@@ -1,5 +1,5 @@
 import inhouse_bot.common_utils.lol_api.tasks as lol
-from typing import List, Dict
+from typing import List, Dict, Tuple
 from inhouse_bot.database_orm import Game, GameParticipant
 from inhouse_bot.dataclasses.GameInfo import GameInfo
 from sqlalchemy import BigInteger
@@ -78,7 +78,7 @@ async def find_team_and_lane_mmr(team: List[GameParticipant]) -> GameInfo:
     return GameInfo(blueTeamMMR, redTeamMMR, teamMMRWithLane)
 
 
-def get_lane_differential(laneMMR: Dict[str, int]) -> int:
+def get_lane_differential(laneMMR: Dict[Tuple[SideEnum, RoleEnum], int]) -> int:
     """
     1. Get each players opponent and attempt to put players of equal level against each other, if they queue for the same role
     """

--- a/inhouse_bot/matchmaking_logic/evaluate_game.py
+++ b/inhouse_bot/matchmaking_logic/evaluate_game.py
@@ -44,18 +44,7 @@ async def find_team_and_lane_mmr(team: List[GameParticipant]) -> GameInfo:
         "CHALLENGERI": 3250,
     }
 
-    laneMMR = {
-        "BLUETOP": 0,
-        "BLUEJGL": 0,
-        "BLUEMID": 0,
-        "BLUEBOT": 0,
-        "BLUESUP": 0,
-        "REDTOP": 0,
-        "REDJGL": 0,
-        "REDMID": 0,
-        "REDBOT": 0,
-        "REDSUP": 0,
-    }
+    laneMMR = {(side, role): 0 for side in SideEnum for role in RoleEnum}
 
     blueTeamMMR = 0
     redTeamMMR = 0
@@ -78,9 +67,7 @@ async def find_team_and_lane_mmr(team: List[GameParticipant]) -> GameInfo:
             redTeamMMR += value
 
         # Storing each players lane mmr
-        if gameparticipant.role in RoleEnum:
-            laneMMRString = str(gameparticipant.side + gameparticipant.role)
-            laneMMR[laneMMRString] = value
+        laneMMR[(gameparticipant.side, gameparticipant.role)] = value
 
     teamMMR = abs(blueTeamMMR - redTeamMMR)
     teamMMRWithLane = teamMMR + get_lane_differential(laneMMR)
@@ -88,8 +75,6 @@ async def find_team_and_lane_mmr(team: List[GameParticipant]) -> GameInfo:
     logging.info(
         f"Blue Team: {blueTeamMMR} | Red Team: {redTeamMMR} | TeamMMRDifferenceWithLane: {teamMMRWithLane}"
     )
-
-    print("\n")
     return GameInfo(blueTeamMMR, redTeamMMR, teamMMRWithLane)
 
 
@@ -97,11 +82,25 @@ def get_lane_differential(laneMMR: Dict[str, int]) -> int:
     """
     1. Get each players opponent and attempt to put players of equal level against each other, if they queue for the same role
     """
-    topDiff = abs(laneMMR["BLUETOP"] - laneMMR["REDTOP"])
-    jgDiff = abs(laneMMR["BLUEJGL"] - laneMMR["REDJGL"])
-    midDiff = abs(laneMMR["BLUEMID"] - laneMMR["REDMID"])
-    botDiff = abs(laneMMR["BLUEBOT"] - laneMMR["REDBOT"])
-    suppDiff = abs(laneMMR["BLUESUP"] - laneMMR["REDSUP"])
+    topDiff = abs(
+        laneMMR[(SideEnum.BLUE, RoleEnum.TOP)] - laneMMR[(SideEnum.RED, RoleEnum.TOP)]
+    )
+
+    jgDiff = abs(
+        laneMMR[(SideEnum.BLUE, RoleEnum.JGL)] - laneMMR[(SideEnum.RED, RoleEnum.JGL)]
+    )
+
+    midDiff = abs(
+        laneMMR[(SideEnum.BLUE, RoleEnum.MID)] - laneMMR[(SideEnum.RED, RoleEnum.MID)]
+    )
+
+    botDiff = abs(
+        laneMMR[(SideEnum.BLUE, RoleEnum.BOT)] - laneMMR[(SideEnum.RED, RoleEnum.BOT)]
+    )
+
+    suppDiff = abs(
+        laneMMR[(SideEnum.BLUE, RoleEnum.SUP)] - laneMMR[(SideEnum.RED, RoleEnum.SUP)]
+    )
     return topDiff + jgDiff + midDiff + botDiff + suppDiff
 
 


### PR DESCRIPTION
**Players used who were in queue** (Made this hardcoded queue to illustrate the point)
![PlayersInQueue](https://user-images.githubusercontent.com/21285730/206165968-47bb7310-fd2c-491a-8b30-62da4087cbd8.png)

**Original Algorithm**
![PreTeamLaneMMR](https://user-images.githubusercontent.com/21285730/206165950-96189cb3-04bf-4286-a5c4-6005eb30e678.png)

**Algorithm With Lane Matchmaking**
![PostTeamLaneMMR](https://user-images.githubusercontent.com/21285730/206165911-7d7ed6d8-267d-4ae4-b936-75d3e50c13a4.png)

In the original algorithm, we look through N games and try to find the smallest team difference amongst those games. Looking at the picture above in the original algorithm there are 8 masters and 2 silver players (Fellow King and FIUMonstar), even though both players queued for MID it didn't matter because order took such a high priority instead of correctness. In this specific game you would get a master v silver, which we don't want, given there was another silver who queued for that exact role.

Now looking at the algorithm with lane matchmaking, we still check to see if both teams difference is small from an MMR standpoint, but we take a deeper look at the matchups and try to find matchups with the smallest differences amongst all roles and add that to the team score. We could have the silver vs a master, but there is actually a game with a lower score where the silver is vs another silver and their difference computes to 0.
